### PR TITLE
Propose new subclades in C.3 and C.5.6

### DIFF
--- a/.auto-generated/subclades.md
+++ b/.auto-generated/subclades.md
@@ -81,6 +81,12 @@
  * representative sequence: B/Moldova/2030521/2023 (EPI_ISL_18037429) [View on Nextstrain](https://nextstrain.org/seasonal-flu/vic/ha/6y?c=subclade&s=B/Moldova/2030521/2023)
  * [View on Nextstrain](https://nextstrain.org/seasonal-flu/vic/ha/6y?branchLabel=Subclade&c=subclade&label=Subclade:C.3)
 
+## C.3.1
+ * parent: [C.3](#C3)
+ * defining mutations or substitutions: HA1:197N, HA1:208S, nuc:700T, nuc:1605C
+ * representative sequence: B/Washington/20/2025 (EPI4474502) [View on Nextstrain](https://nextstrain.org/seasonal-flu/vic/ha/6y?c=subclade&s=B/Washington/20/2025)
+ * [View on Nextstrain](https://nextstrain.org/seasonal-flu/vic/ha/6y?branchLabel=Subclade&c=subclade&label=Subclade:C.3.1)
+
 ## C.4
  * parent: [C](#C)
  * defining mutations or substitutions: HA1:198G, nuc:48C, nuc:228A

--- a/.auto-generated/subclades.md
+++ b/.auto-generated/subclades.md
@@ -143,6 +143,12 @@
    - B/Iowa/29/2023 ([OR629475](https://www.ncbi.nlm.nih.gov/nuccore/OR629475)) [View on Nextstrain](https://nextstrain.org/seasonal-flu/vic/ha/6y?c=subclade&s=B/Iowa/29/2023)
  * [View on Nextstrain](https://nextstrain.org/seasonal-flu/vic/ha/6y?branchLabel=Subclade&c=subclade&label=Subclade:C.5.6)
 
+## C.5.6.1
+ * parent: [C.5.6](#C56)
+ * defining mutations or substitutions: HA1:199A, HA1:128D, HA1:37I
+ * representative sequence: B/Massachusetts/34/2025 (EPI4445622) [View on Nextstrain](https://nextstrain.org/seasonal-flu/vic/ha/6y?c=subclade&s=B/Massachusetts/34/2025)
+ * [View on Nextstrain](https://nextstrain.org/seasonal-flu/vic/ha/6y?branchLabel=Subclade&c=subclade&label=Subclade:C.5.6.1)
+
 ## C.5.7
  * parent: [C.5](#C5)
  * defining mutations or substitutions: HA1:128G, HA1:183K, nuc:195C

--- a/.auto-generated/subclades.tsv
+++ b/.auto-generated/subclades.tsv
@@ -88,6 +88,10 @@ C.5.6	clade	C.5
 C.5.6	HA1	129	N
 C.5.6	nuc	555	T
 C.5.6	nuc	435	G
+C.5.6.1	clade	C.5.6	
+C.5.6.1	HA1	199	A
+C.5.6.1	HA1	128	D
+C.5.6.1	HA1	37	I
 C.5.7	clade	C.5	
 C.5.7	HA1	128	G
 C.5.7	HA1	183	K

--- a/.auto-generated/subclades.tsv
+++ b/.auto-generated/subclades.tsv
@@ -53,6 +53,11 @@ C.3	clade	C
 C.3	HA1	128	K
 C.3	HA1	154	E
 C.3	nuc	882	G
+C.3.1	clade	C.3	
+C.3.1	HA1	197	N
+C.3.1	HA1	208	S
+C.3.1	nuc	700	T
+C.3.1	nuc	1605	C
 C.4	clade	C	
 C.4	HA1	198	G
 C.4	nuc	48	C

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2025-07-30
+
+ - add subclade [C.3.1](https://github.com/influenza-clade-nomenclature/seasonal_B-Vic_HA/blob/5e220b88012ba911ea23fcb2615b2e3dbc62810c/subclades/C.3.1.yml)
+ - add subclade [C.5.6.1](https://github.com/influenza-clade-nomenclature/seasonal_B-Vic_HA/blob/5e220b88012ba911ea23fcb2615b2e3dbc62810c/subclades/C.5.6.1.yml)
+
 # 2023-11-09
 
  - update definition of C.2 and C.4 to include positions in the definition that were previously used to define parent clades, which meant that these clades didn't get assigned properly.

--- a/subclades/C.3.1.yml
+++ b/subclades/C.3.1.yml
@@ -1,0 +1,21 @@
+name: C.3.1
+unaliased_name: A.3.1.2.3.1
+parent: C.3
+representatives:
+- isolate: B/Washington/20/2025
+  source: gisaid
+  accession: EPI4474502
+defining_mutations:
+- locus: HA1
+  position: 197
+  state: N
+- locus: HA1
+  position: 208
+  state: S
+- locus: nuc
+  position: 700
+  state: T
+- locus: nuc
+  position: 1605
+  state: C
+clade: none

--- a/subclades/C.5.6.1.yml
+++ b/subclades/C.5.6.1.yml
@@ -1,0 +1,18 @@
+name: C.5.6.1
+unaliased_name: A.3.1.2.5.6.1
+parent: C.5.6
+representatives:
+- isolate: B/Massachusetts/34/2025
+  source: gisaid
+  accession: EPI4445622
+defining_mutations:
+- locus: HA1
+  position: 199
+  state: A
+- locus: HA1
+  position: 128
+  state: D
+- locus: HA1
+  position: 37
+  state: I
+clade: none


### PR DESCRIPTION
Proposes a new subclade C.3.1 which has reversions at HA1 197 and 208 and has reassorted with a different NA background than its ancestral clade.

<img width="1097" alt="image" src="https://github.com/user-attachments/assets/9916c25f-3cb3-4aea-b4ae-245e286e94d7" />

Proposes a new subclade C.5.6.1 with 199A, 128D, and 37I as shown in @rneher's comment below.